### PR TITLE
Plain bars for free performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,7 +250,7 @@
           </div>
         </div>
         <div class="right-area">
-          <div class="progress progress-striped active">
+          <div class="progress">
             <div class="bar" style="width: {{progress}}%">{{progress}}%</div>
           </div>
           <div class="progress-info">
@@ -287,7 +287,7 @@
             {{#uploadLength}}<span>(up {{#_v.format_size}}{{uploadLength}}{{/_v.format_size}}){{/uploadLength}}
           </div>
           <div class="pull-right">
-            <div class="progress progress-striped">
+            <div class="progress">
               <div class="bar" style="width: {{progress}}%">{{progress}}%</div>
             </div>
           </div>


### PR DESCRIPTION
Hi,

While focused, this site uses too much CPU. Chromium's timeline functionality shows that it has to repaint all the bars few times a second, which takes around 40% of my old CPU. However, if I disable striped+active progressbars, it takes virtually no CPU cycles and only updates on refresh (which is great and doesn't use that much CPU).

In this PR I disable striped bars. While they don't look so fancy, they're still pretty cool :D.
