### PR TITLE
Firefox compatibility problem of context menu over tasks.

### DIFF
--- a/js/yaaw.js
+++ b/js/yaaw.js
@@ -553,9 +553,11 @@ var YAAW = (function() {
           }
           return false;
         }).live("mouseout", function(ev) {
-          if ($.contains(this, ev.toElement) ||
-            $("#task-contextmenu").get(0) == ev.toElement ||
-            $.contains($("#task-contextmenu").get(0), ev.toElement)) {
+          // toElement is not available in Firefox, use relatedTarget instead.
+          var enteredElement = ev.toElement || ev.relatedTarget;
+          if ($.contains(this, enteredElement) ||
+            $("#task-contextmenu").get(0) == ev.enteredElement ||
+            $.contains($("#task-contextmenu").get(0), ev.enteredElement)) {
             return;
           }
           on_gid = null;


### PR DESCRIPTION
Firefox下右键菜单的问题是因为toElement这个属性在Firefox上不存在，但有相对应的relatedTarget。
所以做个小兼容就可以了。
#19 一个月前汇报了这个问题，看来作者似乎对Firefox支持不上心？
