### PR TITLE
使用黑色填充进度文字

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,7 +252,7 @@
         </div>
         <div class="right-area">
           <div class="progress">
-            <div class="bar" style="width: {{progress}}%">{{progress}}%</div>
+            <div class="bar" style="font-weight:bold; color:#000000; width:{{progress}}%">{{progress}}%</div>
           </div>
           <div class="progress-info">
             {{#downloadSpeed}}<span class="download-speed"><i class="icon-download"></i> {{#_v.format_size}}{{downloadSpeed}}{{/_v.format_size}}/s</span>{{/downloadSpeed}}
@@ -289,7 +289,7 @@
           </div>
           <div class="pull-right">
             <div class="progress">
-              <div class="bar" style="width: {{progress}}%">{{progress}}%</div>
+              <div class="bar" style="font-weight:bold; color:#000000; width:{{progress}}%">{{progress}}%</div>
             </div>
           </div>
           <div class="clearfix"></div>


### PR DESCRIPTION
加粗的黑色文字能够在进度条尚未覆盖白色背景时也显示清晰。
