### PR TITLE
should use protocol-relative url to load resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <link href="css/bootstrap-responsive.min.css" rel="stylesheet" />
     <link href="css/main.css" rel="stylesheet" />
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
   </head>
   <body>

--- a/js/aria2.js
+++ b/js/aria2.js
@@ -102,7 +102,7 @@ if (typeof ARIA2=="undefined"||!ARIA2) var ARIA2=(function(){
       $("#add-task-option-wrap").empty().append(YAAW.tpl.add_task_option({}));
       $("#aria2-gsetting").empty().append(YAAW.tpl.aria2_global_setting({}));
 
-      jsonrpc_interface = path || "http://"+(location.host.split(":")[0]||"localhost")+":6800"+"/jsonrpc";
+      jsonrpc_interface = path || "//"+(location.host.split(":")[0]||"localhost")+":6800"+"/jsonrpc";
       var auth_str = request_auth(jsonrpc_interface);
       if (auth_str && auth_str.indexOf('token:') == 0) {
         rpc_secret = auth_str;

--- a/js/yaaw.js
+++ b/js/yaaw.js
@@ -690,7 +690,7 @@ var YAAW = (function() {
 
     setting: {
       init: function() {
-        this.jsonrpc_path = $.Storage.get("jsonrpc_path") || "http://"+(location.host.split(":")[0]||"localhost")+":6800"+"/jsonrpc";
+        this.jsonrpc_path = $.Storage.get("jsonrpc_path") || "//"+(location.host.split(":")[0]||"localhost")+":6800"+"/jsonrpc";
         this.refresh_interval = Number($.Storage.get("refresh_interval") || 10000);
         this.add_task_option = $.Storage.get("add_task_option");
         this.jsonrpc_history = JSON.parse($.Storage.get("jsonrpc_history") || "[]");


### PR DESCRIPTION
As you see, we'll get warning on the demo page(maybe in the toolbar or in console), because the page was loaded via https but the resources were loaded via http protocol, which is not save, so may be blocked by client(browser), so it'll be better to use protocol-relative url to load resource here.

reference: http://www.paulirish.com/2010/the-protocol-relative-url/
