### PR TITLE
Get server address from the url parameter

### DIFF
--- a/js/yaaw.js
+++ b/js/yaaw.js
@@ -729,7 +729,17 @@ var YAAW = (function() {
 
     setting: {
       init: function() {
-        this.jsonrpc_path = $.Storage.get("jsonrpc_path") || location.protocol+"//"+(location.host.split(":")[0]||"localhost")+":6800"+"/jsonrpc";
+        var url_rpc = (function(val) {
+          var result = null,
+          tmp = [];
+          var items = location.search.substr(1).split("&");
+          for (var index = 0; index < items.length; index++) {
+            tmp = items[index].split("=");
+            if (tmp[0] === val) result = decodeURIComponent(tmp[1]);
+          }
+          return result;
+        })("rpc");
+        this.jsonrpc_path = url_rpc || $.Storage.get("jsonrpc_path") || location.protocol+"//"+(location.host.split(":")[0]||"localhost")+":6800"+"/jsonrpc";
         this.refresh_interval = Number($.Storage.get("refresh_interval") || 10000);
         this.add_task_option = $.Storage.get("add_task_option");
         this.jsonrpc_history = JSON.parse($.Storage.get("jsonrpc_history") || "[]");


### PR DESCRIPTION
For someone who would like to clean up the cache very frequently, it is not very convenient to reconfigure the server address all the time. This pull request provides a way that allows users pass the server address from the request URL. So the users may save the address as a shortcut.

The address will basically look like `http://example.com/yaaw/?rpc=http://example.com:6800/jsonrpc

The value of RPC parameter will replace the server address in settings.

I know that passing the server address as a parameter is not safe, but considering personal usage, it is quite ok.

Anyway, well done. This is really an awesome project.