### PR TITLE
prevent dividing task info into two lines

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -188,7 +188,7 @@
 .task .download-speed,
 .task .upload-speed,
 .task .seeders {
-    margin-right: 8px;
+    margin-right: 2px;
 }
 
 #other-tasks .task-info {


### PR DESCRIPTION
On my 1280x laptop task info is divided into two lines. It breaks readability a lot.