### PR TITLE
fix local variable conflict

### DIFF
--- a/js/aria2.js
+++ b/js/aria2.js
@@ -753,8 +753,8 @@ if (typeof ARIA2=="undefined"||!ARIA2) var ARIA2=(function(){
             file.title = file.path.replace(new RegExp("^"+result.dir.replace(/\\/g, "[\\/]")+"/?"), "");
             file.selected = file.selected == "true" ? true : false;
             if (file.uris && file.uris.length) {
-              for (var i=0; i<file.uris.length; i++) {
-                var uri = file.uris[i].uri;
+              for (var j=0; j<file.uris.length; j++) {
+                var uri = file.uris[j].uri;
                 if (result.uris.indexOf(uri) == -1) {
                   result.uris.push(uri);
                 }


### PR DESCRIPTION
for function get_status(), there are 2 for loop: the outer one is loop on result.files, while the inner one loop on files.urls. Their local loop variable share the same name "i" and will cause infinite loop in special use case, change the name of inner one to "j" fix the issue.