### PR TITLE
ignore spaces in urls, ignore empty line.

### DIFF
--- a/js/aria2.js
+++ b/js/aria2.js
@@ -265,7 +265,8 @@ if (typeof ARIA2=="undefined"||!ARIA2) var ARIA2=(function(){
       if (!$.isArray(uris)) uris = [uris];
       var params = [];
       for (var i=0; i<uris.length; i++) {
-        params.push([[uris[i]], options]);
+        var uri = uris[i].trim();
+        if (uri) params.push([[uri], options]);
       };
       ARIA2.batch_request("addUri", params,
         function(result) {


### PR DESCRIPTION
忽略URL前后的空格，忽略空行。

修复以下问题
有空行会提示错误，实际上已成功添加
![failed](https://user-images.githubusercontent.com/22502715/81275808-24c68580-908d-11ea-8fdb-24a0d5b1a628.png)
