### PR TITLE
delete (failure) tasks when restart

### DIFF
--- a/js/aria2.js
+++ b/js/aria2.js
@@ -355,6 +355,8 @@ if (typeof ARIA2=="undefined"||!ARIA2) var ARIA2=(function(){
           ARIA2.request("getOption", [gid], function(result) {
             var options = result.result;
             ARIA2.madd_task(uris, options);
+            //delete old info(mostly failure), won`t delete file from disk actually.
+            ARIA2.remove_result(gid);
           });
         }
       });


### PR DESCRIPTION
when  failure tasks been restarted manually, both will exist in `Other Tasks(waitting, success or failure)`, it will be difficult to make sure whether failure tasks has been restarted especially task failed more than once

this can make sure deletes after new task been created
```
ARIA2.request("getOption", [gid], function(result) {
    var options = result.result;
    ARIA2.madd_task(uris, options);
    //delete old info(mostly failure), won`t delete file from disk actually.
    ARIA2.remove_result(gid);
});
```